### PR TITLE
Added radius-based init_rt_finder.py, updated map_zipper.py

### DIFF
--- a/alignment/init_rt_finder.py
+++ b/alignment/init_rt_finder.py
@@ -1,0 +1,110 @@
+import os
+import copy
+import warnings
+import numpy as np
+import open3d as o3d
+from kiss_matcher import KISSMatcher
+from utils.logger import logger
+
+class InitRTFinder:
+    def __init__(self, params: dict):
+        self.params = params
+        self.map_voxel_size = params["alignment"].get("tgt_voxel_size", 0.5)
+        self.matcher_voxel_size = params["alignment"].get("matcher_voxel_size", 2.0)
+        self.icp_voxel_size = params["alignment"].get("src_voxel_size", 0.15)
+        p_set = params["settings"]
+        self.prev_output_dir = p_set.get("prev_output_dir", "")
+        if self.prev_output_dir:
+            self.central_map_path = os.path.join(self.prev_output_dir, "lifelong_map.pcd")
+        else:
+            self.central_map_path = ""
+        self.query_dir = p_set.get("scans_dir", "")
+        self.query_pose_path = p_set.get("poses_file", "")
+        self.query_start_idx = params["alignment"].get("query_start_idx", 0)
+
+    def load_poses(self, path):
+        poses = []
+        if not os.path.exists(path):
+            logger.error(f"Pose file not found: {path}")
+            return poses
+        with open(path) as f:
+            for line in f:
+                v = list(map(float, line.split()))
+                T = np.eye(4)
+                if len(v) == 12: T[:3, :] = np.array(v).reshape(3, 4)
+                else: T = np.array(v).reshape(4, 4)
+                poses.append(T)
+        return poses
+
+    def build_query_map(self, pcd_dir, poses, voxel):
+        merged = o3d.geometry.PointCloud()
+        for i in range(len(poses)):
+            path = os.path.join(pcd_dir, f"{i:06d}.pcd")
+            if not os.path.exists(path): continue
+            pcd = o3d.io.read_point_cloud(path)
+            pcd.transform(poses[i])
+            if voxel > 0:
+                pcd = pcd.voxel_down_sample(voxel)
+            merged += pcd
+            if i % 100 == 0:
+                merged = merged.voxel_down_sample(voxel)
+        return merged
+
+    def crop_pcd_by_radius(self, pcd, center, radius):
+        pts = np.asarray(pcd.points)
+        if pts.size == 0: return pcd
+        dists = np.linalg.norm(pts - center, axis=1)
+        indices = np.where(dists < radius)[0]
+        return pcd.select_by_index(indices)
+
+    def solve_rt_svd(self, src_pts, tgt_pts):
+        c_src, c_tgt = np.mean(src_pts, 0), np.mean(tgt_pts, 0)
+        H = (src_pts - c_src).T @ (tgt_pts - c_tgt)
+        U, S, Vt = np.linalg.svd(H)
+        R = Vt.T @ U.T
+        if np.linalg.det(R) < 0: 
+            Vt[2, :] *= -1
+            R = Vt.T @ U.T
+        T = np.eye(4)
+        T[:3, :3], T[:3, 3] = R, c_tgt - R @ c_src
+        return T
+
+    def find_initial_transform(self):
+        warnings.filterwarnings("ignore", message=".*Too large.*noise_bound.*")
+        if not os.path.exists(self.central_map_path):
+            logger.error(f"Central map not found: {self.central_map_path}")
+            return np.eye(4)
+            
+        c_map = o3d.io.read_point_cloud(self.central_map_path)
+        if self.map_voxel_size > 0:
+            c_map = c_map.voxel_down_sample(self.map_voxel_size)
+            
+        qp_poses = self.load_poses(self.query_pose_path)
+        q_map = self.build_query_map(self.query_dir, qp_poses, self.map_voxel_size)
+
+        bbox = c_map.get_axis_aligned_bounding_box()
+        map_diag = np.linalg.norm(bbox.get_max_bound() - bbox.get_min_bound())
+        CROP_RADIUS = (map_diag * 0.1) / 2.0
+        logger.info(f"Radius-based initial alignment : radius={CROP_RADIUS:.2f}m")
+
+        matcher = KISSMatcher(self.matcher_voxel_size)
+        res = matcher.match(np.asarray(q_map.points).T, np.asarray(c_map.points).T)
+        T_rel = self.solve_rt_svd(np.array(res[0]).reshape(-1, 3), np.array(res[1]).reshape(-1, 3))
+        warnings.filterwarnings("default")
+
+        q_origin_map = (qp_poses[self.query_start_idx] @ np.array([0, 0, 0, 1]))[:3]
+        q_seg = self.crop_pcd_by_radius(q_map, q_origin_map, CROP_RADIUS)
+        q_origin_in_central = (T_rel @ np.append(q_origin_map, 1.0))[:3]
+        t_seg = self.crop_pcd_by_radius(c_map, q_origin_in_central, CROP_RADIUS)
+        q_seg = q_seg.voxel_down_sample(self.icp_voxel_size) if self.icp_voxel_size > 0 else q_seg
+        t_seg = t_seg.voxel_down_sample(self.icp_voxel_size) if self.icp_voxel_size > 0 else t_seg
+        q_t = copy.deepcopy(q_seg).transform(T_rel)
+        q_t.estimate_normals()
+        t_seg.estimate_normals()
+        reg = o3d.pipelines.registration.registration_icp(
+            q_t, t_seg, 2.0, np.eye(4), 
+            o3d.pipelines.registration.TransformationEstimationPointToPlane()
+        )
+        final_T = reg.transformation @ T_rel
+        logger.info(f"Radius-based initial alignment complete | fit: {reg.fitness:.4f} | rmse: {reg.inlier_rmse:.4f}")
+        return final_T

--- a/alignment/map_zipper.py
+++ b/alignment/map_zipper.py
@@ -8,8 +8,9 @@ from tqdm import tqdm
 from utils.session import Session
 from utils.session_map import SessionMap
 from utils.logger import logger
+from alignment.init_rt_finder import InitRTFinder
 from alignment.matcher.open3d_scan_matcher import Open3DScanMatcher
-from alignment.matcher.pygicp_scan_matcher import PyGICPScanMatcher
+#from alignment.matcher.pygicp_scan_matcher import PyGICPScanMatcher
 from alignment.global_registration import register_with_fpfh_ransac
 
 
@@ -21,7 +22,8 @@ class MapZipper:
         # Load parameters and initialize data loaders
         with open(config_path, 'r') as f:
             self.params = yaml.safe_load(f)
-
+            
+        #self.matcher_cls = Open3DScanMatcher
         matcher_name = self.params["alignment"].get("matcher", "Open3DScanMatcher")
         self.matcher_cls = {"Open3DScanMatcher": Open3DScanMatcher,
                             "PyGICPScanMatcher": PyGICPScanMatcher,
@@ -66,11 +68,29 @@ class MapZipper:
         return pcd.crop(aabb)
 
     def _init_transform(self) -> np.ndarray:
-        p = self.params["alignment"]
-        init_tf = np.eye(4)
-        if "init_transform" in p:
-            init_tf = np.array(p["init_transform"]).reshape(4, 4)
-        return init_tf
+        p_align = self.params["alignment"]
+        p_settings = self.params["settings"]
+        
+        init_tf = np.array(p_align.get("init_transform", np.eye(4))).reshape(4, 4)
+        is_identity = np.allclose(init_tf, np.eye(4))
+
+        if not is_identity:
+            return init_tf
+
+        prev_out = p_settings.get("prev_output_dir", "")
+        if prev_out and os.path.exists(prev_out):
+            logger.info("Cannot find config initTF. Executing Kiss-Matcher based initTF finder.")
+            prev_scans = os.path.join(os.path.dirname(prev_out.rstrip('/')), "Scans")
+            f_params = copy.deepcopy(self.params)
+            f_params["settings"]["prev_scans_dir"] = prev_scans
+            
+            try:
+                finder = InitRTFinder(f_params)
+                return finder.find_initial_transform()
+            except Exception as e:
+                logger.error(f"InitRTFinder Error: {e}")
+        logger.warning("Failed to find initTF: use identity instead.")
+        return np.eye(4)
 
     def _is_nonoverlapping(self, point: np.ndarray, threshold: float) -> bool:
         # Nearest-neighbor distance test


### PR DESCRIPTION
Added [init_rt_finder.py]
- Input: scans/poses/pre-generated global map (lifelong_map.pcd) from a previous session. 
- Process: Performs global registration using KISS-Matcher to find a rough alignment, followed by a radius-based point-to-plane ICP to refine the transformation.
- Output: 4×4 initial transformation matrix.

Modified [map_zipper.py]
- Updated to automatically trigger the init_rt_finder module 1. if a prior map exists and 2. if init_tf undetected in .yaml.